### PR TITLE
Minor fix in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,9 @@ getBalance();
 ```
 
 
-### Documentation for TronBox 1.0
+### Documentation for TronWeb 1.0
 
-Are you still using TronBox 1. You can find documentation here:
+Are you still using TronWeb 1. You can find documentation here:
 * [English](http://doc.tron.network/en)
 * [Chinese](http://doc.tron.network/)
 


### PR DESCRIPTION
This is a minor fix in the README where we talk about TronBox instead of TronWeb.