### PR TITLE
Restoring map-support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tronweb",
-    "version": "2.0.19",
+    "version": "2.0.20",
     "description": "JavaScript SDK that encapsulates the TRON Node HTTP API",
     "main": "dist/TronWeb.node.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
         "eventemitter3": "^3.1.0",
         "js-sha3": "^0.8.0",
         "jssha": "^2.3.1",
+        "source-map-support": "^0.5.9",
         "validator": "^10.7.1"
     },
     "devDependencies": {
-        "source-map-support": "^0.5.9",
         "@babel/core": "^7.0.0",
         "@babel/plugin-proposal-class-properties": "^7.0.0",
         "@babel/plugin-proposal-numeric-separator": "^7.0.0",


### PR DESCRIPTION
Moving `source-map-support` from dependences to devDependences we introduced an error:
```
Error: Cannot find module 'source-map-support/register'
    at Function.Module._resolveFilename (module.js:548:15)
    at Function.Module._load (module.js:475:25)
    at Module.require (module.js:597:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/tron/app/node_modules/tronweb/dist/TronWeb.node.js:1:1160)
    at r (/tron/app/node_modules/tronweb/dist/TronWeb.node.js:1:186)
    at Module.<anonymous> (/tron/app/node_modules/tronweb/dist/TronWeb.node.js:1:4757)
    at r (/tron/app/node_modules/tronweb/dist/TronWeb.node.js:1:186)
    at /tron/app/node_modules/tronweb/dist/TronWeb.node.js:1:985
    at Object.<anonymous> (/tron/app/node_modules/tronweb/dist/TronWeb.node.js:1:995)
```
I am restoring the original position.