### PR TITLE
Adding an option to pre-push.js for new branches

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,11 @@
         "test:node": "node scripts/test-node.js && npx mocha ./test/*.js",
         "test": "npm run-script test:browser && npm run-script test:node"
     },
+    "husky": {
+        "hooks": {
+            "pre-push": "node ./scripts/pre-push.js"
+        }
+    },
     "dependencies": {
         "@babel/runtime": "^7.0.0",
         "axios": "^0.18.0",

--- a/scripts/pre-push.js
+++ b/scripts/pre-push.js
@@ -1,18 +1,25 @@
 const { execSync } = require('child_process');
 
 const branch = execSync('git name-rev --name-only HEAD').toString().split('\n')[0];
-const unpushed = execSync(`git log origin/${ branch }..${ branch } --name-status`).toString().split('\n');
+let unpushed;
+
+try {
+    unpushed = execSync(`git log origin/${ branch }..${ branch } --name-status`).toString().split('\n');
+} catch(ex) {
+    // the branch hasn't ever been pushed
+    unpushed = execSync(`git log HEAD...origin --name-status`).toString().split('\n');
+}
 
 const isSourceChanged = unpushed.some(logLine => logLine.includes('src/'));
 const isDistTracked = isSourceChanged ? unpushed.some(logLine => logLine.includes('dist/TronWeb.js')) : true;
 
 if(!isDistTracked) {
-    console.log('Please run yarn build -p');
+    console.log('Please run: yarn build');
     process.exit(1);
 }
 
 try {
-    execSync('npm run test:node');
+    execSync('yarn test:node');
 } catch(ex) {
     if(ex.stdout)
         console.log(ex.stdout.toString());


### PR DESCRIPTION
When you just create a new branch. The first time you try to push it, the pre-push script was causing a blocking error. This change will address the issue.

I also changed the message because the option `-p` is unnecessary since `production` is the default environment in our webpack config file.

Finally, for consistency, it runs the tests using yarn.