### PR TITLE
Setting a more reasonable default value for origin_energy_limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tronweb",
-    "version": "2.1.13",
+    "version": "2.1.14",
     "description": "JavaScript SDK that encapsulates the TRON Node HTTP API",
     "main": "dist/TronWeb.node.js",
     "scripts": {
@@ -10,7 +10,8 @@
         "example": "node ./examples/server",
         "test:browser": "node scripts/test-browser.js && npx karma start --single-run --browsers ChromeHeadless,Firefox,Edge",
         "test:node": "node scripts/test-node.js && npx mocha ./test/*.js",
-        "test": "npm run-script test:browser && npm run-script test:node"
+        "test": "npm run-script test:browser && npm run-script test:node",
+        "build:dev": "NODE_ENV=development npm run build"
     },
     "husky": {
         "hooks": {

--- a/src/lib/transactionBuilder.js
+++ b/src/lib/transactionBuilder.js
@@ -314,7 +314,7 @@ export default class TransactionBuilder {
             feeLimit = 1_000_000_000,
             callValue = 0,
             userFeePercentage = 0,
-            originEnergyLimit = 100_000,
+            originEnergyLimit = 10_000_000,
             parameters = [],
             name = "",
         } = options;


### PR DESCRIPTION
The default value was too low and could make a contract unusable.
1e8 is more reasonable.