### PR TITLE
Prepared for 3.2.2-trx10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tronweb",
-    "version": "2.1.15",
+    "version": "2.1.16",
     "description": "JavaScript SDK that encapsulates the TRON Node HTTP API",
     "main": "dist/TronWeb.node.js",
     "scripts": {


### PR DESCRIPTION
The new trx10 proposal is coming. This PR prepares TronWeb to support it during contract creation adding the two new parameters — tokenValue and tokenId — required in that case. Since the two parameters cause the throwing of an error in current implementation, they are passed to the http api only if passed to the method.