### PR TITLE
add param to get raw response from getEventResult

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -200,7 +200,8 @@ export default class TronWeb extends EventEmitter {
             page,
             onlyConfirmed,
             onlyUnconfirmed,
-            previousLastEventFingerprint
+            previousLastEventFingerprint,
+            rawResponse
         } = Object.assign({
             sinceTimestamp: 0,
             eventName: false,
@@ -272,7 +273,7 @@ export default class TronWeb extends EventEmitter {
                 return callback(data);
 
             return callback(null,
-                data.map(event => utils.mapEvent(event))
+                rawResponse === true ? data : data.map(event => utils.mapEvent(event))
             );
         }).catch(err => callback((err.response && err.response.data) || err));
     }


### PR DESCRIPTION
New option `rawResponse` for `getEventResult` function, if it's value is `true` then raw response will be returned, without your mapping. For example, i need to get `event_index` from response, but your mapping doesn't support this, probably i'll need something else in future, therefore just adding `event_index` in mapping isn't a solution.