### PR TITLE
add getConfirmedCurrentBlock

### DIFF
--- a/src/lib/trx.js
+++ b/src/lib/trx.js
@@ -33,6 +33,15 @@ export default class Trx {
         }).catch(err => callback(err));
     }
 
+    getConfirmedCurrentBlock(callback = false) {
+        if(!callback)
+            return this.injectPromise(this.getConfirmedCurrentBlock);
+
+        this.tronWeb.solidityNode.request('walletsolidity/getnowblock').then(block => {
+            callback(null, block);
+        }).catch(err => callback(err));
+    }
+
     getBlock(block = this.tronWeb.defaultBlock, callback = false) {
         if(utils.isFunction(block)) {
             callback = block;


### PR DESCRIPTION
Added getConfirmedCurrentBlock function which uses solidityNode.
I'll be useful when you need to get current block info only from confirmed state blocks.