### PR TITLE
Plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tronweb",
-    "version": "2.2.2",
+    "version": "2.2.1",
     "description": "JavaScript SDK that encapsulates the TRON Node HTTP API",
     "main": "dist/TronWeb.node.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tronweb",
-    "version": "2.2.2",
+    "version": "2.2.3",
     "description": "JavaScript SDK that encapsulates the TRON Node HTTP API",
     "main": "dist/TronWeb.node.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tronweb",
-    "version": "2.2.1",
+    "version": "2.2.2",
     "description": "JavaScript SDK that encapsulates the TRON Node HTTP API",
     "main": "dist/TronWeb.node.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tronweb",
-    "version": "2.2.0",
+    "version": "2.2.2",
     "description": "JavaScript SDK that encapsulates the TRON Node HTTP API",
     "main": "dist/TronWeb.node.js",
     "scripts": {
@@ -28,6 +28,7 @@
         "eventemitter3": "^3.1.0",
         "js-sha3": "^0.8.0",
         "jssha": "^2.3.1",
+        "semver": "^5.6.0",
         "validator": "^10.7.1"
     },
     "devDependencies": {

--- a/scripts/pre-push.js
+++ b/scripts/pre-push.js
@@ -13,14 +13,6 @@ try {
 
 console.log(execSync('yarn build').toString())
 
-// const isSourceChanged = unpushed.some(logLine => logLine.includes('src/'));
-// const isDistTracked = isSourceChanged ? unpushed.some(logLine => logLine.includes('dist/TronWeb.js')) : true;
-//
-// if(!isDistTracked) {
-//     console.log(chalk.red('Please run: yarn build'));
-//     process.exit(1);
-// }
-
 let errors = false
 const test = spawn('yarn', ['test:node'])
 

--- a/scripts/pre-push.js
+++ b/scripts/pre-push.js
@@ -11,6 +11,8 @@ try {
     unpushed = execSync(`git log HEAD...origin --name-status`).toString().split('\n');
 }
 
+execSync('yarn build')
+
 // const isSourceChanged = unpushed.some(logLine => logLine.includes('src/'));
 // const isDistTracked = isSourceChanged ? unpushed.some(logLine => logLine.includes('dist/TronWeb.js')) : true;
 //

--- a/scripts/pre-push.js
+++ b/scripts/pre-push.js
@@ -11,7 +11,7 @@ try {
     unpushed = execSync(`git log HEAD...origin --name-status`).toString().split('\n');
 }
 
-execSync('yarn build')
+console.log(execSync('yarn build').toString())
 
 // const isSourceChanged = unpushed.some(logLine => logLine.includes('src/'));
 // const isDistTracked = isSourceChanged ? unpushed.some(logLine => logLine.includes('dist/TronWeb.js')) : true;

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import querystring from 'querystring';
 import TransactionBuilder from 'lib/transactionBuilder';
 import Trx from 'lib/trx';
 import Contract from 'lib/contract';
+import Plugin from 'lib/plugin';
 
 import {keccak256} from 'js-sha3';
 
@@ -16,6 +17,7 @@ export default class TronWeb extends EventEmitter {
     static TransactionBuilder = TransactionBuilder;
     static Trx = Trx;
     static Contract = Contract;
+    static Plugin = Plugin;
 
     constructor(fullNode, solidityNode, eventServer = false, privateKey = false) {
         super();
@@ -57,6 +59,7 @@ export default class TronWeb extends EventEmitter {
 
         this.transactionBuilder = new TransactionBuilder(this);
         this.trx = new Trx(this);
+        this.plugin = new Plugin(this);
         this.utils = utils;
 
         this.injectPromise = utils.promiseInjector(this);

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import utils from 'utils';
 import BigNumber from 'bignumber.js';
 import EventEmitter from 'eventemitter3';
 import querystring from 'querystring';
+import {version} from '../package.json';
 
 import TransactionBuilder from 'lib/transactionBuilder';
 import Trx from 'lib/trx';
@@ -18,6 +19,7 @@ export default class TronWeb extends EventEmitter {
     static Trx = Trx;
     static Contract = Contract;
     static Plugin = Plugin;
+    static version = version;
 
     constructor(fullNode, solidityNode, eventServer = false, privateKey = false) {
         super();

--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -8,6 +8,7 @@ export default class Plugin {
         if (!tronWeb || !tronWeb instanceof TronWeb)
             throw new Error('Expected instance of TronWeb');
         this.tronWeb = tronWeb;
+        this.pluginNoOverride = ['register'];
     }
 
     register(Plugin) {
@@ -32,10 +33,10 @@ export default class Plugin {
                 let methods = pluginInterface.components[component]
                 let pluginNoOverride = this.tronWeb[component].pluginNoOverride || []
                 for (let method in methods) {
-                    if (this.tronWeb[component][method] &&
+                    if (method === 'constructor' || (this.tronWeb[component][method] &&
                         (pluginNoOverride.includes(method) // blacklisted methods
                             || /^_/.test(method)) // private methods
-                    ) {
+                    )) {
                         result.skipped.push(method)
                         continue
                     }

--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -1,27 +1,32 @@
 import TronWeb from 'index';
 import utils from 'utils';
+import semver from 'semver';
 
 export default class Plugin {
 
     constructor(tronWeb = false) {
-        if(!tronWeb || !tronWeb instanceof TronWeb)
+        if (!tronWeb || !tronWeb instanceof TronWeb)
             throw new Error('Expected instance of TronWeb');
-
         this.tronWeb = tronWeb;
     }
 
-    register(plugin) {
+    async register(Plugin) {
         let pluginInterface
+        const plugin = new Plugin(this.tronWeb)
         if (utils.isFunction(plugin.pluginInterface)) {
-            pluginInterface = plugin.pluginInterface(this.tronWeb)
+            pluginInterface = plugin.pluginInterface()
         }
-        for (let i in pluginInterface) {
-            if (!this.tronWeb[i]) {
-                TronWeb[i] = {}
-
+        if (semver.satisfies(TronWeb.version, pluginInterface.supportedVersions)) {
+            for (let klass in pluginInterface.packages) {
+                if (this.tronWeb.hasOwnProperty(klass)) {
+                    // method override
+                    let methods = pluginInterface.packages[klass]
+                    for (let method in methods) {
+                        this.tronWeb[klass][method] = methods[method].bind(this.tronWeb[klass])
+                    }
+                }
             }
-
         }
     }
+}
 
-};

--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -1,0 +1,27 @@
+import TronWeb from 'index';
+import utils from 'utils';
+
+export default class Plugin {
+
+    constructor(tronWeb = false) {
+        if(!tronWeb || !tronWeb instanceof TronWeb)
+            throw new Error('Expected instance of TronWeb');
+
+        this.tronWeb = tronWeb;
+    }
+
+    register(plugin) {
+        let pluginInterface
+        if (utils.isFunction(plugin.pluginInterface)) {
+            pluginInterface = plugin.pluginInterface(this.tronWeb)
+        }
+        for (let i in pluginInterface) {
+            if (!this.tronWeb[i]) {
+                TronWeb[i] = {}
+
+            }
+
+        }
+    }
+
+};

--- a/src/lib/trx.js
+++ b/src/lib/trx.js
@@ -12,6 +12,8 @@ export default class Trx {
 
         this.tronWeb = tronWeb;
         this.injectPromise = utils.promiseInjector(this);
+
+        this.methodBlacklist = ['parseToken'];
     }
 
     parseToken(token) {

--- a/src/lib/trx.js
+++ b/src/lib/trx.js
@@ -12,9 +12,6 @@ export default class Trx {
 
         this.tronWeb = tronWeb;
         this.injectPromise = utils.promiseInjector(this);
-
-        // example
-        // this.pluginNoOverride = ['_parseToken'];
     }
 
     _parseToken(token) {

--- a/src/lib/trx.js
+++ b/src/lib/trx.js
@@ -13,10 +13,11 @@ export default class Trx {
         this.tronWeb = tronWeb;
         this.injectPromise = utils.promiseInjector(this);
 
-        this.methodBlacklist = ['parseToken'];
+        // example
+        // this.pluginNoOverride = ['_parseToken'];
     }
 
-    parseToken(token) {
+    _parseToken(token) {
         return {
             ...token,
             name: this.tronWeb.toUtf8(token.name),
@@ -394,7 +395,7 @@ export default class Trx {
                 return callback(null, {});
 
             const tokens = assetIssue.map(token => {
-                return this.parseToken(token);
+                return this._parseToken(token);
             }).reduce((tokens, token) => {
                 return tokens[token.name] = token, tokens;
             }, {});
@@ -419,7 +420,7 @@ export default class Trx {
             if(!token.name)
                 return callback('Token does not exist');
 
-            callback(null, this.parseToken(token));
+            callback(null, this._parseToken(token));
         }).catch(err => callback(err));
     }
 
@@ -493,7 +494,7 @@ export default class Trx {
 
         if(!limit) {
             return this.tronWeb.fullNode.request('wallet/getassetissuelist').then(({assetIssue = []}) => {
-                callback(null, assetIssue.map(token => this.parseToken(token)));
+                callback(null, assetIssue.map(token => this._parseToken(token)));
             }).catch(err => callback(err));
         }
 
@@ -501,7 +502,7 @@ export default class Trx {
             offset: parseInt(offset),
             limit: parseInt(limit)
         }, 'post').then(({assetIssue = []}) => {
-            callback(null, assetIssue.map(token => this.parseToken(token)));
+            callback(null, assetIssue.map(token => this._parseToken(token)));
         }).catch(err => callback(err));
     }
 
@@ -1104,7 +1105,7 @@ export default class Trx {
             if(!token.name)
                 return callback('Token does not exist');
 
-            callback(null, this.parseToken(token));
+            callback(null, this._parseToken(token));
         }).catch(err => callback(err));
     }
 
@@ -1124,7 +1125,7 @@ export default class Trx {
             if(!token.name)
                 return callback('Token does not exist');
 
-            callback(null, this.parseToken(token));
+            callback(null, this._parseToken(token));
         }).catch(err => callback(err));
     }
 

--- a/test/helpers/getnowblock.js
+++ b/test/helpers/getnowblock.js
@@ -1,12 +1,12 @@
 
 class GetNowBlock {
 
-    constructor(tronWeb = false) {
-        if (!tronWeb)
-            throw new Error('Expected instance of TronWeb');
-
-        this.tronWeb = tronWeb;
-    }
+    // constructor(tronWeb = false) {
+    //     if (!tronWeb)
+    //         throw new Error('Expected instance of TronWeb');
+    //
+    //     this.tronWeb = tronWeb;
+    // }
 
     async getLatestBlock(callback = false) {
 
@@ -21,10 +21,11 @@ class GetNowBlock {
 
     pluginInterface() {
         return {
-            supportedVersions: '^2.2.2',
-            packages: {
+            requires: '^2.2.2',
+            components: {
                 trx: {
-                    getCurrentBlock: this.getLatestBlock
+                    getCurrentBlock: this.getLatestBlock,
+                    parseToken: function () {}
                 }
             }
         }

--- a/test/helpers/getnowblock.js
+++ b/test/helpers/getnowblock.js
@@ -8,7 +8,7 @@ class GetNowBlock {
     //     this.tronWeb = tronWeb;
     // }
 
-    async getLatestBlock(callback = false) {
+    async someMethod(callback = false) {
 
         if(!callback)
             return this.injectPromise(this.getCurrentBlock);
@@ -24,8 +24,16 @@ class GetNowBlock {
             requires: '^2.2.2',
             components: {
                 trx: {
-                    getCurrentBlock: this.getLatestBlock,
-                    parseToken: function () {}
+                    // will be overridden
+                    getCurrentBlock: this.someMethod,
+
+                    // will be added
+                    getLatestBlock: this.someMethod,
+
+                    // will be skipped
+                    _parseToken: function () {}
+
+
                 }
             }
         }

--- a/test/helpers/getnowblock.js
+++ b/test/helpers/getnowblock.js
@@ -23,7 +23,7 @@ class GetNowBlock {
 
     pluginInterface() {
         return {
-            requires: '^2.2.1',
+            requires: '^2.2.2',
             components: {
                 trx: {
                     // will be overridden

--- a/test/helpers/getnowblock.js
+++ b/test/helpers/getnowblock.js
@@ -1,0 +1,34 @@
+
+class GetNowBlock {
+
+    constructor(tronWeb = false) {
+        if (!tronWeb)
+            throw new Error('Expected instance of TronWeb');
+
+        this.tronWeb = tronWeb;
+    }
+
+    async getLatestBlock(callback = false) {
+
+        if(!callback)
+            return this.injectPromise(this.getCurrentBlock);
+
+        this.tronWeb.fullNode.request('wallet/getnowblock').then(block => {
+            block.fromPlugin = true
+            callback(null, block);
+        }).catch(err => callback(err));
+    }
+
+    pluginInterface() {
+        return {
+            supportedVersions: '^2.2.2',
+            packages: {
+                trx: {
+                    getCurrentBlock: this.getLatestBlock
+                }
+            }
+        }
+    }
+}
+
+module.exports = GetNowBlock

--- a/test/helpers/getnowblock.js
+++ b/test/helpers/getnowblock.js
@@ -21,7 +21,7 @@ class GetNowBlock {
 
     pluginInterface() {
         return {
-            requires: '^2.2.2',
+            requires: '^2.2.1',
             components: {
                 trx: {
                     // will be overridden

--- a/test/helpers/getnowblock.js
+++ b/test/helpers/getnowblock.js
@@ -1,6 +1,8 @@
 
 class GetNowBlock {
 
+    // In a real case, you should have this in order to allow the library to work stand-alone. But for this test, it is more clear this way.
+
     // constructor(tronWeb = false) {
     //     if (!tronWeb)
     //         throw new Error('Expected instance of TronWeb');

--- a/test/lib/plugin.test.js
+++ b/test/lib/plugin.test.js
@@ -1,0 +1,41 @@
+const chai = require('chai');
+const {FULL_NODE_API} = require('../helpers/config');
+const assertThrow = require('../helpers/assertThrow');
+const tronWebBuilder = require('../helpers/tronWebBuilder');
+const TronWeb = tronWebBuilder.TronWeb;
+const GetNowBlock = require('../helpers/getnowblock');
+
+const assert = chai.assert;
+
+describe('TronWeb.lib.plugin', async function () {
+
+    let tronWeb;
+
+    before(async function () {
+        tronWeb = tronWebBuilder.createInstance();
+    });
+
+    describe('#constructor()', function () {
+
+        it('should have been set a full instance in tronWeb', function () {
+
+            assert.instanceOf(tronWeb.plugin, TronWeb.Plugin);
+        });
+
+    });
+
+    describe.only("#plug GetNowBlock", async function () {
+
+        it('should register the plugin GetNowBlock', async function () {
+
+            tronWeb.plugin.register(GetNowBlock)
+            const result = await tronWeb.trx.getCurrentBlock()
+
+            assert.isTrue(result.fromPlugin)
+
+        })
+
+    });
+
+
+});

--- a/test/lib/plugin.test.js
+++ b/test/lib/plugin.test.js
@@ -25,13 +25,16 @@ describe('TronWeb.lib.plugin', async function () {
 
     });
 
-    describe.only("#plug GetNowBlock", async function () {
+    describe("#plug GetNowBlock", async function () {
 
         it('should register the plugin GetNowBlock', async function () {
 
-            tronWeb.plugin.register(GetNowBlock)
+            let result = tronWeb.plugin.register(GetNowBlock)
+            assert.isTrue(result.skipped.includes('_parseToken'))
+            assert.isTrue(result.plugged.includes('getCurrentBlock'))
+            assert.isTrue(result.plugged.includes('getLatestBlock'))
 
-            const result = await tronWeb.trx.getCurrentBlock()
+            result = await tronWeb.trx.getCurrentBlock()
             assert.isTrue(result.fromPlugin)
 
         })

--- a/test/lib/plugin.test.js
+++ b/test/lib/plugin.test.js
@@ -4,6 +4,7 @@ const assertThrow = require('../helpers/assertThrow');
 const tronWebBuilder = require('../helpers/tronWebBuilder');
 const TronWeb = tronWebBuilder.TronWeb;
 const GetNowBlock = require('../helpers/getnowblock');
+const jlog = require('../helpers/jlog')
 
 const assert = chai.assert;
 
@@ -29,8 +30,8 @@ describe('TronWeb.lib.plugin', async function () {
         it('should register the plugin GetNowBlock', async function () {
 
             tronWeb.plugin.register(GetNowBlock)
-            const result = await tronWeb.trx.getCurrentBlock()
 
+            const result = await tronWeb.trx.getCurrentBlock()
             assert.isTrue(result.fromPlugin)
 
         })


### PR DESCRIPTION
Implements a simple plugin architecture for plugins.
A plugin can override methods and add new methods to tronWeb subclasses (transactionBuilder, trx, etc.) except if a method is private (starts with `_`) or is listed in the property `pluginNoOverride`.
The related test shows how to plugin a substitution for `getCurrentBlock`.