### PR TITLE
Fix resource node in method#_watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tronweb",
-    "version": "2.2.6",
+    "version": "2.2.7",
     "description": "JavaScript SDK that encapsulates the TRON Node HTTP API",
     "main": "dist/TronWeb.node.js",
     "scripts": {

--- a/src/lib/contract/method.js
+++ b/src/lib/contract/method.js
@@ -289,15 +289,25 @@ export default class Method {
                 const events = await this.tronWeb.getEventResult(this.contract.address, {
                     since: sinceTimestamp,
                     eventName: this.name,
-                    sort: 'block_timestamp'
+                    sort: 'block_timestamp',
+                    size: 50
                 });
                 const [latestEvent] = events.sort((a, b) => b.block - a.block);
                 const newEvents = events.filter((event, index) => {
 
-
-                    // TODO use unconfirmed
-                    if(options.resourceNode && !RegExp(options.resourceNode, 'i').test(event.resourceNode))
-                        return false;
+                    if(options.resourceNode) {
+                        if (/full/.test(options.resourceNode)) {
+                            if ((event.resourceNode && !/full/.test(event.resourceNode))
+                                || !event._unconfirmed) {
+                                return false
+                            }
+                        } else {
+                            if ((event.resourceNode && !/solidity/.test(event.resourceNode))
+                                || event._unconfirmed) {
+                                return false
+                            }
+                        }
+                    }
 
                     const duplicate = events.slice(0, index).some(priorEvent => (
                         JSON.stringify(priorEvent) == JSON.stringify(event)


### PR DESCRIPTION
Fix the missed `resourceNode` property in TronGrid2 events result, when watching events.