### PR TITLE
Fix map event

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tronweb",
-    "version": "2.2.8",
+    "version": "2.2.9",
     "description": "JavaScript SDK that encapsulates the TRON Node HTTP API",
     "main": "dist/TronWeb.node.js",
     "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -285,9 +285,15 @@ export default class TronWeb extends EventEmitter {
         }).catch(err => callback((err.response && err.response.data) || err));
     }
 
-    getEventByTransactionID(transactionID = false, callback = false) {
+    getEventByTransactionID(transactionID = false, options = {}, callback = false) {
+
+        if (utils.isFunction(options)) {
+            callback = options;
+            options = {};
+        }
+
         if(!callback)
-            return this.injectPromise(this.getEventByTransactionID, transactionID);
+            return this.injectPromise(this.getEventByTransactionID, transactionID, options);
 
         if(!this.eventServer)
             return callback('No event server configured');
@@ -300,7 +306,7 @@ export default class TronWeb extends EventEmitter {
                 return callback(data);
 
             return callback(null,
-                data.map(event => utils.mapEvent(event))
+                options.rawResponse === true ? data : data.map(event => utils.mapEvent(event))
             );
         }).catch(err => callback((err.response && err.response.data) || err));
     }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -90,15 +90,19 @@ const utils = {
     },
 
     mapEvent(event) {
-        return {
+        let data = {
             block: event.block_number,
             timestamp: event.block_timestamp,
             contract: event.contract_address,
             name: event.event_name,
             transaction: event.transaction_id,
             result: event.result,
-            resourceNode: event.resource_Node
+            resourceNode: event.resource_Node || (event._unconfirmed ? 'fullNode' : 'solidityNode')
         };
+        if (event._fingerprint) {
+            data.fingerprint = event._fingerprint;
+        }
+        return data;
     },
 
     parseEvent(event, {inputs: abi}) {


### PR DESCRIPTION
This extends the fix in https://github.com/tronprotocol/tron-web/pull/180 to getEventByTransactionID.
Also, it fixes a minor issue in `mapEvent`, so that `resourceNode` can be deducted by `_unconfirmed`.