### PR TITLE
Removing mixed approach when instantiating tronWeb

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,9 @@ In order to contribute you can
 
 ## Recent History
 
+__2.3.2__
+* Remove mixed approach instantiating tronWeb. Before you could pass the servers as an object, and the privateKey as a separate parameter. Now, you pass them either in the options object or in the params.
+
 __2.3.1__
 * Adds support for not-tld domain, like http://localhost
 * Improve the new format, allow passing the privateKey as a property in the option object

--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ you can also set a
 which works as a jolly. If you do so, though, the more precise specification has priority.
 Supposing you are using a server which provides everything, like TronGrid, you can instantiate TronWeb as:
 
-The easiest way to instantiate tronWeb is to run
 ```js
 const tronWeb = new TronWeb({
     fullHost: 'https://api.trongrid.io',
@@ -122,7 +121,7 @@ const tronWeb = new TronWeb({
 })
 ```
 
-For retro-compatibility, you can continue to use the old approach, where any parameter is passed separately:
+For retro-compatibility, though, you can continue to use the old approach, where any parameter is passed separately:
 ```js
 const tronWeb = new TronWeb(fullNode, solidityNode, eventServer, privateKey)
 

--- a/README.md
+++ b/README.md
@@ -99,41 +99,58 @@ First off, in your javascript file, define TronWeb:
 ```js
 const TronWeb = require('tronweb')
 ```
+
+When you instantiate TronWeb you can define
+
+* fullNode
+* solidityNode
+* eventServer
+* privateKey
+
+you can also set a
+
+* fullHost
+
+which works as a jolly. If you do so, though, the more precise specification has priority.
+Supposing you are using a server which provides everything, like TronGrid, you can instantiate TronWeb as:
+
 The easiest way to instantiate tronWeb is to run
 ```js
 const tronWeb = new TronWeb({
     fullHost: 'https://api.trongrid.io',
-    privateKey: '...'
+    privateKey: 'your private key'
 })
 ```
-but you can continue to use the old way:
+
+For retro-compatibility, you can continue to use the old approach, where any parameter is passed separately:
 ```js
 const tronWeb = new TronWeb(fullNode, solidityNode, eventServer, privateKey)
 
 ```
 
-Valid alternatives are:
+If you are, for example, using a server as full and solidity node, and another server for the events, you can set it as:
 
 ```js
 const tronWeb = new TronWeb({
     fullHost: 'https://api.trongrid.io',
-    eventServer: 'https://api.someotherevent.io'
-  },
-  privateKey: '...'
-)
-```
-where fullHost defines fullNode and solidityNode while the eventServer is specified, and the privateKey is passed separately.
-
-```js
-const tronWeb = new TronWeb({
-    fullNode: 'https://api.trongrid.io',
-    solidityNode: 'https://api/somesolidity.io'
-    eventServer: 'https://api.somevent.io',
-    privateKey: '...'
+    eventServer: 'https://api.someotherevent.io',
+    privateKey: 'your private key'
   }
 )
 ```
-similar to the old approach
+
+If you are using different servers for anything, you can do
+```js
+const tronWeb = new TronWeb({
+    fullNode: 'https://some-node.tld',
+    solidityNode: 'https://some-other-node.tld'
+    eventServer: 'https://some-event-server.tld',
+    privateKey: 'your private key'
+  }
+)
+```
+
+
 
 ## A full example
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ __2.3.1__
 
 __2.3.0__
 * Introduces new format to instantiate tronWeb, passing an options object instead that `fullNode`, `solidityNode` and `eventServer` as separate params
-* Fixes bug in `_watch` which causes an ethernal update of the `since` parameter
+* Fixes bug in `_watch` which causes a continuous update of the `since` parameter
 
 ## Licence
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tronweb",
-    "version": "2.3.1",
+    "version": "2.3.2",
     "description": "JavaScript SDK that encapsulates the TRON Node HTTP API",
     "main": "dist/TronWeb.node.js",
     "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -22,15 +22,16 @@ export default class TronWeb extends EventEmitter {
     static version = version;
 
     constructor(options = false,
+                // for retro-compatibility:
                 solidityNode = false, eventServer = false, privateKey = false) {
         super();
 
         let fullNode;
         if (typeof options === 'object' && (options.fullNode || options.fullHost)) {
-            privateKey = options.privateKey || solidityNode;
             fullNode = options.fullNode || options.fullHost;
             solidityNode = options.solidityNode || options.fullHost;
             eventServer = options.eventServer || options.fullHost;
+            privateKey = options.privateKey;
         } else {
             fullNode = options;
         }


### PR DESCRIPTION
This changes a little bit the way we instantiate TronWeb. The following is taken from the updated README:

------
When you instantiate TronWeb you can define

* fullNode
* solidityNode
* eventServer
* privateKey

you can also set a

* fullHost

which works as a jolly. If you do so, though, the more precise specification has priority.
Supposing you are using a server which provides everything, like TronGrid, you can instantiate TronWeb as:
```js
const tronWeb = new TronWeb({
    fullHost: 'https://api.trongrid.io',
    privateKey: 'your private key'
})
```

For retro-compatibility, you can continue to use the old approach, where any parameter is passed separately:
```js
const tronWeb = new TronWeb(fullNode, solidityNode, eventServer, privateKey)

```

If you are, for example, using a server as full and solidity node, and another server for the events, you can set it as:

```js
const tronWeb = new TronWeb({
    fullHost: 'https://api.trongrid.io',
    eventServer: 'https://api.someotherevent.io',
    privateKey: 'your private key'
  }
)
```

If you are using different servers for anything, you can do
```js
const tronWeb = new TronWeb({
    fullNode: 'https://some-node.tld',
    solidityNode: 'https://some-other-node.tld'
    eventServer: 'https://some-event-server.tld',
    privateKey: 'your private key'
  }
)
```