### PR TITLE
Add options to plugin#register

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,7 @@
 .DS_Store
 test
 coverage
+.idea
+.scratch
+scripts
+src

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tronweb",
-    "version": "2.3.2",
+    "version": "2.3.4",
     "description": "JavaScript SDK that encapsulates the TRON Node HTTP API",
     "main": "dist/TronWeb.node.js",
     "scripts": {

--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -11,7 +11,7 @@ export default class Plugin {
         this.pluginNoOverride = ['register'];
     }
 
-    register(Plugin) {
+    register(Plugin, options) {
         let pluginInterface = {
             requires: '0.0.0',
             components: {}
@@ -22,7 +22,7 @@ export default class Plugin {
         }
         const plugin = new Plugin(this.tronWeb)
         if (utils.isFunction(plugin.pluginInterface)) {
-            pluginInterface = plugin.pluginInterface()
+            pluginInterface = plugin.pluginInterface(options)
         }
         if (semver.satisfies(TronWeb.version, pluginInterface.requires)) {
             for (let component in pluginInterface.components) {

--- a/src/paramValidator/index.js
+++ b/src/paramValidator/index.js
@@ -67,6 +67,7 @@ export default class Validator {
                         callback(this.invalid(param));
                         return true;
                     }
+                    break;
 
                 case 'notEqual':
                     if (normalized[names[0]] === normalized[names[1]]) {

--- a/test/helpers/getnowblock.js
+++ b/test/helpers/getnowblock.js
@@ -1,4 +1,6 @@
 
+let someParameter
+
 class GetNowBlock {
 
     // In a real case, you should have this in order to allow the library to work stand-alone. But for this test, it is more clear this way.
@@ -21,9 +23,16 @@ class GetNowBlock {
         }).catch(err => callback(err));
     }
 
-    pluginInterface() {
+    getSomeParameter() {
+        return someParameter;
+    }
+
+    pluginInterface(options) {
+        if (options.someParameter) {
+            someParameter = options.someParameter
+        }
         return {
-            requires: '^2.2.2',
+            requires: '^2.2.4',
             components: {
                 trx: {
                     // will be overridden
@@ -31,6 +40,7 @@ class GetNowBlock {
 
                     // will be added
                     getLatestBlock: this.someMethod,
+                    getSomeParameter: this.getSomeParameter,
 
                     // will be skipped
                     _parseToken: function () {}

--- a/test/lib/plugin.test.js
+++ b/test/lib/plugin.test.js
@@ -8,7 +8,7 @@ const jlog = require('../helpers/jlog')
 
 const assert = chai.assert;
 
-describe('TronWeb.lib.plugin', async function () {
+describe.only('TronWeb.lib.plugin', async function () {
 
     let tronWeb;
 
@@ -29,13 +29,20 @@ describe('TronWeb.lib.plugin', async function () {
 
         it('should register the plugin GetNowBlock', async function () {
 
-            let result = tronWeb.plugin.register(GetNowBlock)
+            const someParameter = 'someValue'
+
+            let result = tronWeb.plugin.register(GetNowBlock, {
+                someParameter
+            })
             assert.isTrue(result.skipped.includes('_parseToken'))
             assert.isTrue(result.plugged.includes('getCurrentBlock'))
             assert.isTrue(result.plugged.includes('getLatestBlock'))
 
             result = await tronWeb.trx.getCurrentBlock()
             assert.isTrue(result.fromPlugin)
+
+            result = await tronWeb.trx.getSomeParameter()
+            assert.equal(result, someParameter)
 
         })
 

--- a/test/lib/plugin.test.js
+++ b/test/lib/plugin.test.js
@@ -8,7 +8,7 @@ const jlog = require('../helpers/jlog')
 
 const assert = chai.assert;
 
-describe.only('TronWeb.lib.plugin', async function () {
+describe('TronWeb.lib.plugin', async function () {
 
     let tronWeb;
 


### PR DESCRIPTION
When registering a new plugin, it can be necessary to pass some options to the pluginInterface. This PR adds this possibility.