### PR TITLE
Adding the version as a property of the instance, and not only of the…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tronweb",
-    "version": "2.3.8",
+    "version": "2.3.9",
     "description": "JavaScript SDK that encapsulates the TRON Node HTTP API",
     "main": "dist/TronWeb.node.js",
     "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,7 @@ export default class TronWeb extends EventEmitter {
             'sha3', 'toHex', 'toUtf8', 'fromUtf8',
             'toAscii', 'fromAscii', 'toDecimal', 'fromDecimal',
             'toSun', 'fromSun', 'toBigNumber', 'isAddress',
-            'createAccount', 'address'
+            'createAccount', 'address', 'version'
         ].forEach(key => {
             this[key] = TronWeb[key];
         });


### PR DESCRIPTION
This allows the get the version of TronWeb using the instance. Before it is possible to get the version with 
```
console.log(TronWeb.version)
```
but wallets like TronLink don't inject the class, but only the instance. This PR allows to get the version with
```
console.log(tronWeb.version)
```
