### PR TITLE
replace new transaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tronweb",
-    "version": "2.4.0",
+    "version": "2.4.1",
     "description": "JavaScript SDK that encapsulates the TRON Node HTTP API",
     "main": "dist/TronWeb.node.js",
     "scripts": {

--- a/src/lib/trx.js
+++ b/src/lib/trx.js
@@ -734,7 +734,7 @@ export default class Trx {
         }).catch(err => callback(err));
     }
 
-    async getSignWeight(transaction, permissionId = 0, callback = false) {
+    async getSignWeight(transaction, permissionId, callback = false) {
         if (utils.isFunction(permissionId)) {
             callback = permissionId;
             permissionId = 0;
@@ -746,9 +746,11 @@ export default class Trx {
         if (!utils.isObject(transaction) || !transaction.raw_data || !transaction.raw_data.contract)
             return callback('Invalid transaction provided');
 
-        if (!transaction.raw_data.contract.Permission_id) {
-            transaction.raw_data.contract[0].Permission_id = permissionId;
-        }
+        if (utils.isInteger(permissionId))
+            transaction.raw_data.contract[0].Permission_id = parseInt(permissionId);
+
+        if (typeof transaction.raw_data.contract.Permission_id !== 'number')
+            transaction.raw_data.contract[0].Permission_id = 0;
 
         if (!utils.isObject(transaction))
             return callback('Invalid transaction provided');

--- a/src/lib/trx.js
+++ b/src/lib/trx.js
@@ -737,7 +737,7 @@ export default class Trx {
     async getSignWeight(transaction, permissionId, callback = false) {
         if (utils.isFunction(permissionId)) {
             callback = permissionId;
-            permissionId = 0;
+            permissionId = undefined;
         }
 
         if (!callback)
@@ -748,7 +748,9 @@ export default class Trx {
 
         if (utils.isInteger(permissionId)) {
             transaction.raw_data.contract[0].Permission_id = parseInt(permissionId);
-        } else if (typeof transaction.raw_data.contract.Permission_id !== 'number') {
+        }
+
+        if (typeof transaction.raw_data.contract[0].Permission_id !== 'number') {
             transaction.raw_data.contract[0].Permission_id = 0;
         }
 

--- a/src/lib/trx.js
+++ b/src/lib/trx.js
@@ -682,7 +682,7 @@ export default class Trx {
 
         // check if private key insides permission list
         const address = this.tronWeb.address.toHex(this.tronWeb.address.fromPrivateKey(privateKey)).toLowerCase();
-        const signWeight = await this.getSignWeight(transaction);
+        const signWeight = await this.getSignWeight(transaction, permissionId);
 
         if (signWeight.result.code === 'PERMISSION_ERROR') {
             return callback(signWeight.result.message);
@@ -701,8 +701,13 @@ export default class Trx {
             return callback(privateKey + ' already sign transaction');
         }
 
-        // reset transaction id
-        transaction.txID = signWeight.transaction.txid;
+        // reset transaction
+        if (signWeight.transaction && signWeight.transaction.transaction) {
+            transaction = signWeight.transaction.transaction;
+            transaction.raw_data.contract[0].Permission_id = permissionId;
+        } else {
+            return callback('Invalid transaction provided');
+        }
 
         // sign
         try {
@@ -729,9 +734,21 @@ export default class Trx {
         }).catch(err => callback(err));
     }
 
-    async getSignWeight(transaction, callback = false) {
+    async getSignWeight(transaction, permissionId = 0, callback = false) {
+        if (utils.isFunction(permissionId)) {
+            callback = permissionId;
+            permissionId = 0;
+        }
+
         if (!callback)
-            return this.injectPromise(this.getSignWeight, transaction);
+            return this.injectPromise(this.getSignWeight, transaction, permissionId);
+
+        if (!utils.isObject(transaction) || !transaction.raw_data || !transaction.raw_data.contract)
+            return callback('Invalid transaction provided');
+
+        if (!transaction.raw_data.contract.Permission_id) {
+            transaction.raw_data.contract[0].Permission_id = permissionId;
+        }
 
         if (!utils.isObject(transaction))
             return callback('Invalid transaction provided');

--- a/src/lib/trx.js
+++ b/src/lib/trx.js
@@ -746,11 +746,11 @@ export default class Trx {
         if (!utils.isObject(transaction) || !transaction.raw_data || !transaction.raw_data.contract)
             return callback('Invalid transaction provided');
 
-        if (utils.isInteger(permissionId))
+        if (utils.isInteger(permissionId)) {
             transaction.raw_data.contract[0].Permission_id = parseInt(permissionId);
-
-        if (typeof transaction.raw_data.contract.Permission_id !== 'number')
+        } else if (typeof transaction.raw_data.contract.Permission_id !== 'number') {
             transaction.raw_data.contract[0].Permission_id = 0;
+        }
 
         if (!utils.isObject(transaction))
             return callback('Invalid transaction provided');

--- a/src/lib/trx.js
+++ b/src/lib/trx.js
@@ -748,9 +748,7 @@ export default class Trx {
 
         if (utils.isInteger(permissionId)) {
             transaction.raw_data.contract[0].Permission_id = parseInt(permissionId);
-        }
-
-        if (typeof transaction.raw_data.contract[0].Permission_id !== 'number') {
+        } else if (typeof transaction.raw_data.contract[0].Permission_id !== 'number') {
             transaction.raw_data.contract[0].Permission_id = 0;
         }
 

--- a/test/lib/trx.test.js
+++ b/test/lib/trx.test.js
@@ -92,9 +92,10 @@ describe('TronWeb.trx', function () {
             const transaction = await tronWeb.transactionBuilder.sendTrx(accounts.hex[1], 10e8, accounts.hex[0]);
 
             // sign and verify sign weight
-            let signedTransaction, signWeight;
+            let signedTransaction = transaction;
+            let signWeight;
             for (let i = 0; i < threshold; i++) {
-                signedTransaction = await tronWeb.trx.multiSign(transaction, accounts.pks[i], 0);
+                signedTransaction = await tronWeb.trx.multiSign(signedTransaction, accounts.pks[i], 0);
                 signWeight = await tronWeb.trx.getSignWeight(signedTransaction);
                 if (i == threshold - 1) {
                     assert.equal(signWeight.approved_list.length, threshold);
@@ -105,7 +106,7 @@ describe('TronWeb.trx', function () {
             }
 
             // get approved list
-            const approvedList = await tronWeb.trx.getApprovedList(transaction);
+            const approvedList = await tronWeb.trx.getApprovedList(signedTransaction);
             assert.isTrue(approvedList.approved_list.length === threshold);
 
             // broadcast multi-sign transaction
@@ -143,6 +144,7 @@ describe('TronWeb.trx', function () {
             let signedTransaction = await tronWeb.trx.multiSign(transaction, accounts.pks[0], 2);
             signedTransaction = await tronWeb.trx.multiSign(signedTransaction, accounts.pks[1], 2);
             signedTransaction = await tronWeb.trx.multiSign(signedTransaction, accounts.pks[2], 2);
+
             assert.equal(signedTransaction.signature.length, 3);
 
             // broadcast multi-sign transaction
@@ -157,10 +159,11 @@ describe('TronWeb.trx', function () {
             const transaction = await tronWeb.transactionBuilder.sendTrx(accounts.hex[1], 10e8, accounts.hex[0]);
 
             // sign and verify sign weight
-            let signedTransaction, signWeight;
+            let signedTransaction = transaction;
+            let signWeight;
             for (let i = 0; i < threshold; i++) {
-                signedTransaction = await tronWeb.trx.multiSign(transaction, accounts.pks[i], 2);
-                signWeight = await tronWeb.trx.getSignWeight(signedTransaction);
+                signedTransaction = await tronWeb.trx.multiSign(signedTransaction, accounts.pks[i], 2);
+                signWeight = await tronWeb.trx.getSignWeight(signedTransaction, 2);
                 if (i == threshold - 1) {
                     assert.equal(signWeight.approved_list.length, threshold);
                 } else {
@@ -170,7 +173,7 @@ describe('TronWeb.trx', function () {
             }
 
             // get approved list
-            const approvedList = await tronWeb.trx.getApprovedList(transaction);
+            const approvedList = await tronWeb.trx.getApprovedList(signedTransaction);
             assert.isTrue(approvedList.approved_list.length === threshold);
 
             // broadcast multi-sign transaction


### PR DESCRIPTION
1. Use whole new transaction from getSignWeight instead of only use new tx id if sign by active permission.
2. Improve test.