### PR TITLE
Make methods static

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ In order to contribute you can
 
 ## Recent History
 
+__2.5.1__
+* Adds static methods `Trx.signMessage` and `Trx.verifySignature
+
+__2.5.0__
+* Allows freeBandwidth, freeBandwidthLimit, frozenAmount and frozenDuration to be zero
+
 __2.3.7__
 * Get rid of jssha to reduce the size of the package a little bit.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tronweb",
-    "version": "2.4.4",
+    "version": "2.5.0",
     "description": "JavaScript SDK that encapsulates the TRON Node HTTP API",
     "main": "dist/TronWeb.node.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tronweb",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "description": "JavaScript SDK that encapsulates the TRON Node HTTP API",
     "main": "dist/TronWeb.node.js",
     "scripts": {


### PR DESCRIPTION
This extract `signMessage` and `verifySignature` from inside the methods `sign` and `verifyMessage` and make them static. The advantage is that this way they can be called without setting fullnode, eventserver, etc.