### PR TITLE
Resolve conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ In order to contribute you can
 
 ## Recent History
 
-__2.5.1__
-* Adds static methods `Trx.signMessage` and `Trx.verifySignature
+__2.5.2__
+* Adds static methods `Trx.signString` and `Trx.verifySignature
 
 __2.5.0__
 * Allows freeBandwidth, freeBandwidthLimit, frozenAmount and frozenDuration to be zero

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tronweb",
-    "version": "2.5.1",
+    "version": "2.5.2",
     "description": "JavaScript SDK that encapsulates the TRON Node HTTP API",
     "main": "dist/TronWeb.node.js",
     "scripts": {

--- a/src/lib/trx.js
+++ b/src/lib/trx.js
@@ -611,7 +611,7 @@ export default class Trx {
                 return callback('Expected hex message input');
 
             try {
-                const signatureHex = Trx.signMessage(transaction, useTronHeader, privateKey)
+                const signatureHex = Trx.signString(transaction, privateKey, useTronHeader)
                 return callback(null, signatureHex);
             } catch (ex) {
                 callback(ex);
@@ -641,7 +641,7 @@ export default class Trx {
         }
     }
 
-    static signMessage(message, useTronHeader, privateKey) {
+    static signString(message, privateKey, useTronHeader) {
         message = message.replace(/^0x/,'');
         const signingKey = new SigningKey(privateKey);
         const messageBytes = [

--- a/src/lib/trx.js
+++ b/src/lib/trx.js
@@ -559,7 +559,7 @@ export default class Trx {
         callback('Signature does not match');
     }
 
-    static verifySignature(message, address, signature, useTronHeader) {
+    static verifySignature(message, address, signature, useTronHeader = true) {
         message = message.replace(/^0x/,'');
         signature = signature.replace(/^0x/,'');
         const messageBytes = [

--- a/src/lib/trx.js
+++ b/src/lib/trx.js
@@ -641,7 +641,7 @@ export default class Trx {
         }
     }
 
-    static signString(message, privateKey, useTronHeader) {
+    static signString(message, privateKey, useTronHeader = true) {
         message = message.replace(/^0x/,'');
         const signingKey = new SigningKey(privateKey);
         const messageBytes = [


### PR DESCRIPTION
Fix a name conflict introduced by https://github.com/tronprotocol/tron-web/pull/269 since a method with the name `signMessage` already existed, as an alias. Now the new name is `signString`.